### PR TITLE
feat: mentoring room list, create room

### DIFF
--- a/src/components/Live/CreateRoomModal.tsx
+++ b/src/components/Live/CreateRoomModal.tsx
@@ -1,0 +1,75 @@
+import React, { useState } from 'react';
+import CreateScheduleModal from './CreateScheduleModal';
+
+type CreateRoomModalProps = {
+  onClose: () => void;
+};
+
+const CreateRoomModal: React.FC<CreateRoomModalProps> = ({ onClose }) => {
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [step, setStep] = useState(1);
+
+  const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setTitle(e.target.value);
+  };
+
+  const handleDescriptionChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setDescription(e.target.value);
+  };
+
+  const handleNextClick = () => {
+    // axios로 방 데이터 추가
+    console.log({ title, description });
+    setStep(2);
+  };
+
+  return (
+    <div>
+      {step === 1 && (
+        <div className="fixed z-10 inset-0 overflow-y-auto">
+          <div className="flex items-center justify-center min-h-screen">
+            <div className="bg-gray-200 rounded-lg p-6">
+              <h2 className="text-lg font-bold mb-4">방 생성</h2>
+              <form>
+                <div className="mb-4">
+                  <label htmlFor="title" className="block mb-2 font-bold">
+                    방 제목
+                  </label>
+                  <input
+                    id="title"
+                    type="text"
+                    className="w-full border-gray-300 rounded-md px-4 py-2"
+                    onChange={(e) => setTitle(e.target.value)}
+                  />
+                </div>
+                <div className="mb-4">
+                  <label htmlFor="description" className="block mb-2 font-bold">
+                    방 소개글
+                  </label>
+                  <input
+                    id="description"
+                    type="text"
+                    className="w-full border-gray-300 rounded-md px-4 py-2"
+                    onChange={(e) => setDescription(e.target.value)}
+                  />
+                </div>
+                <div className="flex justify-end">
+                  <button type='button' className="bg-blue-500 text-white px-4 py-2 rounded-md" onClick={handleNextClick}>
+                    스케쥴 추가
+                  </button>
+                  <button type="button" className="mr-4" onClick={onClose}>
+                    취소
+                  </button>
+                </div>
+              </form>
+            </div>
+          </div>
+        </div>
+      )}
+      {step === 2 && <CreateScheduleModal onClose={onClose} />}
+    </div>
+  );
+};
+
+export default CreateRoomModal;

--- a/src/components/Live/CreateScheduleModal.tsx
+++ b/src/components/Live/CreateScheduleModal.tsx
@@ -1,0 +1,102 @@
+import React, { useState } from 'react';
+
+import Paper from '@mui/material/Paper';
+import {
+    Scheduler,
+    WeekView,
+    Appointments
+} from "@devexpress/dx-react-scheduler-material-ui";
+import { ViewState } from '@devexpress/dx-react-scheduler';
+
+interface CreateScheduleModalProps {
+    onClose: () => void;
+}
+
+interface Schedule {
+    start: Date;
+    end: Date;
+}
+
+const CustomAppointment: React.FC = (props: any) => {
+    const handleEventClick = () => {
+        if (window.confirm('해당 시간에 추가하시겠습니까?')) {
+            alert('스케줄이 완료되었습니다.');
+        }
+    };
+
+    return (
+        <Appointments.Appointment {...props} onClick={handleEventClick} />
+    );
+};
+
+const CreateScheduleModal: React.FC<CreateScheduleModalProps> = ({ onClose }) => {
+    const [schedule, setSchedule] = useState<Schedule>({ start: new Date(), end: new Date() });
+
+    const events = [
+        {
+            title: '예약 가능한 시간',
+            startDate: new Date(),
+            endDate: new Date(new Date().setHours(new Date().getHours() + 1)),
+        },
+        {
+            title: '예약 가능한 시간',
+            startDate: new Date(new Date().setHours(new Date().getHours() + 2)),
+            endDate: new Date(new Date().setHours(new Date().getHours() + 3)),
+        },
+    ];
+
+    const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+        console.log(schedule);
+        // 날짜 데이터 axios
+        onClose();
+    };
+
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const { name, value } = e.target;
+        setSchedule(prev => ({ ...prev, [name]: value }));
+    };
+
+    const handleStartDateChange = (date: Date | null) => {
+        if (date) {
+            setSchedule(prev => ({ ...prev, start: date }));
+        }
+    };
+
+    const handleEndDateChange = (date: Date | null) => {
+        if (date) {
+            setSchedule(prev => ({ ...prev, end: date }));
+        }
+    };
+
+    return (
+        <Paper>
+            <div className="fixed z-10 inset-0 overflow-y-auto">
+                <div className="flex items-center justify-center min-h-screen">
+                    <div className="bg-gray-200 rounded-lg p-6">
+                        <h2 className="text-lg font-bold mb-4">방 생성</h2>
+                        <form>
+                            <div className="calendar">
+                                <Scheduler data={events} height={600}>
+                                    <ViewState defaultCurrentDate={new Date()} />
+                                    <WeekView startDayHour={9} endDayHour={22} />
+                                    <Appointments appointmentComponent={CustomAppointment} />
+                                </Scheduler>
+                                <div className="flex justify-end">
+                                    <button type='submit' className="bg-blue-500 text-white px-4 py-2 rounded-md" onClick={(e) => handleSubmit}>
+                                        완료
+                                    </button>
+                                    <button type="button" className="mr-4" onClick={onClose}>
+                                        취소
+                                    </button>
+                                </div>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </Paper>
+    )
+}
+
+export default CreateScheduleModal;

--- a/src/components/Live/LiveList.tsx
+++ b/src/components/Live/LiveList.tsx
@@ -1,0 +1,49 @@
+import { useState } from 'react';
+
+import CreateRoomModal from './CreateRoomModal';
+import SearchBar from './SearchBar';
+import RoomList from './RoomList';
+import React from 'react';
+
+const LiveList: React.FC = () => {
+    const [isModalOpen, setIsModalOpen] = useState(false);
+
+    const rooms = [
+        { id: 1, title: 'Video 1', description: '...', mentorName: 'Mentor 1', thumbnailUrl: 'https://picsum.photos/id/237/200/300' },
+        { id: 2, title: 'Video 2', description: '...', mentorName: 'Mentor 2', thumbnailUrl: 'https://picsum.photos/id/238/200/300' },
+        { id: 3, title: 'Video 3', description: '...', mentorName: 'Mentor 3', thumbnailUrl: 'https://picsum.photos/id/239/200/300' },
+        { id: 4, title: 'Video 4', description: '...', mentorName: 'Mentor 4', thumbnailUrl: 'https://picsum.photos/id/240/200/300' },
+        { id: 5, title: 'Video 5', description: '...', mentorName: 'Mentor 5', thumbnailUrl: 'https://picsum.photos/id/241/200/300' },
+        { id: 6, title: 'Video 6', description: '...', mentorName: 'Mentor 6', thumbnailUrl: 'https://picsum.photos/id/242/200/300' },
+    ];
+
+    const handleOpenModal = () => {
+        setIsModalOpen(true);
+    };
+
+    const handleSearch = (query: string) => {
+        console.log(`Searching for "${query}"...`);
+        // Perform search using query parameter
+    };
+
+    return (
+        <div className="flex flex-col justify-center items-center h-screen">
+            <div className="w-1/2">
+                <SearchBar onSearch={handleSearch}></SearchBar>
+            </div>
+            <div className="h-32 flex items-center">
+                <button
+                    className="py-2 px-4 bg-transparent text-red-600 font-semibold border border-red-600 rounded hover:bg-red-600 hover:text-white hover:border-transparent transition ease-in duration-200 transform hover:-translate-y-1 active:translate-y-0"
+                    onClick={handleOpenModal}>
+                    방 생성
+                </button>
+            </div>
+            <div>
+                <RoomList rooms={rooms}></RoomList>
+            </div>
+            {isModalOpen && <CreateRoomModal onClose={() => setIsModalOpen(false)} />}
+        </div>
+    );
+};
+
+export default LiveList;

--- a/src/components/Live/RoomList.tsx
+++ b/src/components/Live/RoomList.tsx
@@ -1,0 +1,31 @@
+import React, { useState } from 'react';
+
+interface Room {
+    id: number;
+    title: string;
+    description: string;
+    mentorName: string;
+    thumbnailUrl: string;
+}
+
+interface RoomListProps {
+    rooms: Room[];
+}
+
+const RoomList: React.FC<RoomListProps> = ({ rooms }) => {
+
+    return (
+        <div className="flex flex-wrap justify-center">
+            {rooms.map((room) => (
+                <div key={room.id} className="w-1/3 p-4 flex flex-col justify-center items-center">
+                    <img className="h-50" src={room.thumbnailUrl} alt={room.title} />
+                    <h2 className="text-lg font-semibold mt-2">{room.title}</h2>
+                    <h3 className=''>{room.description}</h3>
+                    <h3 className=''>{room.mentorName}</h3>
+                </div>
+            ))}
+        </div>
+    );
+}
+
+export default RoomList;

--- a/src/components/Live/SearchBar.tsx
+++ b/src/components/Live/SearchBar.tsx
@@ -1,0 +1,39 @@
+import { useState } from "react";
+import "tailwindcss/tailwind.css";
+
+interface Props {
+  onSearch: (query: string) => void;
+}
+
+const SearchBar: React.FC<Props> = ({ onSearch }) => {
+  const [query, setQuery] = useState("");
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setQuery(e.target.value);
+  };
+
+  const handleFormSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    onSearch(query);
+  };
+
+  return (
+    <form onSubmit={handleFormSubmit} className="w-full flex">
+      <input
+        type="text"
+        placeholder="검색어를 입력해주세요."
+        value={query}
+        onChange={handleInputChange}
+        className="border border-gray-300 py-2 px-4 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-600 flex-1"
+      />
+      <button
+        type="submit"
+        className="bg-blue-600 text-white py-2 px-4 rounded-lg ml-2"
+      >
+        Search
+      </button>
+    </form>
+  );
+};
+
+export default SearchBar;

--- a/src/pages/Mentoring.tsx
+++ b/src/pages/Mentoring.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import ShowMentoring from 'components/Live/ShowMentoring';
 import ShowSchedule from 'components/Live/ShowSchedule';
+import LiveList from '../components/Live/LiveList';
 
 const Mentoring = () => {
   const [showPopup, setShowPopup] = useState(false); // 팝업 창 취소
@@ -69,13 +70,14 @@ const Mentoring = () => {
       {showScheduler ? (
         <ShowSchedule events={events} />
       ) : ( // 지수 님이 담당하는 방 전체 목록 이 만들어지면 팝업 여부 추가
-        <div>
-          {/* 방 만들어졌다는 전제 하에 */}
-          <button onClick={togglePopup}>방 버튼</button> 
-          {showPopup && (
-            <ShowMentoring handleClose={togglePopup} />
-          )}
-        </div>
+        // <div>
+        //   {/* 방 만들어졌다는 전제 하에 */}
+        //   <button onClick={togglePopup}>방 버튼</button> 
+        //   {showPopup && (
+        //     <ShowMentoring handleClose={togglePopup} />
+        //   )}
+        // </div>
+        <LiveList></LiveList>
       )}
     </div>
   );


### PR DESCRIPTION
## 🤔 Motivation

- 멘토링룸 목록 전체 조회 시 레이아웃 구성
- 멘토링룸 및 그에 대한 일정 추가를 할 수 있는 모달 창 레이아웃 구성

<br>

## 💡 Key Changes

- 멘토링룸 목록 전체 조회할 때 한 줄에 3개씩 나오도록 하며, 무한 스크롤은 추후 백엔드와 연결해 실 데이터 가져올 때 함께 구현 예정입니다.
- 멘토링룸 생성 모달 창에서는 첫번째 방 이름과 소개글을 입력 받고 `다음` 을 클릭했을 때 백엔드로 바로 방 생성 요청을 보냅니다.
- 다음으로 일정 추가할 때, 현재는 참여중인 일정을 보여주는 calendar 로 동일하게 보여주도록 하려고 했지만 팀원과의 의논 결과 왼쪽에 monthly calendar를 두고 날짜를 클릭하면 오른쪽에 가능한 시간을 보여주는 형식으로 변경예정입니다.

<br>

## 👨‍👨‍👧‍👦 To Reviewers

- @kcs-developers/start-dream-team 

close #22 
close #23 
