### PR TITLE
feat: 내 일정 모두 불러와서 scheduler에 보여주기 및 일정 추가

### DIFF
--- a/src/components/live/CreateRoomModal.tsx
+++ b/src/components/live/CreateRoomModal.tsx
@@ -19,6 +19,7 @@ const CreateRoomModal: React.FC<CreateRoomModalProps> = ({ onClose, events }) =>
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [step, setStep] = useState(1);
+  const [mentoringRoomId, setMentoringRoomId] = useState<number>();
 
   const handleNextClick = () => {
     if (title === '' || description === '') {
@@ -37,12 +38,14 @@ const CreateRoomModal: React.FC<CreateRoomModalProps> = ({ onClose, events }) =>
         }
       })
         .then((res) => {
+          setMentoringRoomId(res.data['data']);
           console.log(res);
+          setStep(2);
         })
         .catch((err) => {
+          window.alert('방이 정상적으로 생성되지 못했습니다.');
           console.log(err);
         })
-      setStep(2);
     }
   };
 
@@ -89,7 +92,7 @@ const CreateRoomModal: React.FC<CreateRoomModalProps> = ({ onClose, events }) =>
           </div>
         </div>
       )}
-      {step === 2 && <CreateScheduleModal onClose={onClose} events={events} />}
+      {step === 2 && <CreateScheduleModal onClose={onClose} events={events} mentoringRoomId={mentoringRoomId} />}
     </div>
   );
 };

--- a/src/components/live/CreateRoomModal.tsx
+++ b/src/components/live/CreateRoomModal.tsx
@@ -5,40 +5,45 @@ import axios from 'axios';
 
 type CreateRoomModalProps = {
   onClose: () => void;
+  events: EventProp[]
 };
 
-const baseURL = 'http://localhost:9002/api/room'
+interface EventProp {
+  title: string;
+  startDate: Date;
+  endDate: Date;
+  type: string;
+};
 
-const CreateRoomModal: React.FC<CreateRoomModalProps> = ({ onClose }) => {
+const CreateRoomModal: React.FC<CreateRoomModalProps> = ({ onClose, events }) => {
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [step, setStep] = useState(1);
 
-  const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setTitle(e.target.value);
-  };
-
-  const handleDescriptionChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    setDescription(e.target.value);
-  };
-
   const handleNextClick = () => {
-    // axios로 방 데이터 추가
-    axios({
-      url: `${baseURL}`,
-      method: 'post',
-      data: {
-        title: title,
-        description: description,
-        // mentor Id 수정 필요
-        mentorId: 1
-      }
-    })
-    .then((res) => {
-      console.log(res);
-    })
-    console.log({ title, description });
-    setStep(2);
+    if (title === '' || description === '') {
+      window.alert('방 제목과 소개글을 채워주세요.');
+    }
+    else {
+      // axios로 방 데이터 추가
+      axios({
+        url: `http://localhost:9002/api/room`,
+        method: 'post',
+        data: {
+          title: title,
+          description: description,
+          // mentor Id 수정 필요
+          mentorId: 1
+        }
+      })
+        .then((res) => {
+          console.log(res);
+        })
+        .catch((err) => {
+          console.log(err);
+        })
+      setStep(2);
+    }
   };
 
   return (
@@ -57,6 +62,7 @@ const CreateRoomModal: React.FC<CreateRoomModalProps> = ({ onClose }) => {
                   type="text"
                   className="w-full border-gray-300 rounded-md px-4 py-2"
                   onChange={(e) => setTitle(e.target.value)}
+                  required
                 />
               </div>
               <div className="mb-4">
@@ -68,6 +74,7 @@ const CreateRoomModal: React.FC<CreateRoomModalProps> = ({ onClose }) => {
                   type="text"
                   className="w-full border-gray-300 rounded-md px-4 py-2"
                   onChange={(e) => setDescription(e.target.value)}
+                  required
                 />
               </div>
               <div className="flex justify-end">
@@ -82,7 +89,7 @@ const CreateRoomModal: React.FC<CreateRoomModalProps> = ({ onClose }) => {
           </div>
         </div>
       )}
-      {step === 2 && <CreateScheduleModal onClose={onClose} />}
+      {step === 2 && <CreateScheduleModal onClose={onClose} events={events} />}
     </div>
   );
 };

--- a/src/components/live/CreateScheduleModal.tsx
+++ b/src/components/live/CreateScheduleModal.tsx
@@ -18,6 +18,7 @@ import { ViewState } from '@devexpress/dx-react-scheduler';
 interface CalendarProps {
     onClose: () => void;
     events: EventProp[];
+    mentoringRoomId: number | undefined;
 };
 
 interface EventProp {
@@ -43,7 +44,7 @@ const resources = [{
 const baseURL = 'http://localhost:9002/api/schedules';
 const memberId = 1;
 
-const CreateScheduleDate: React.FC<CalendarProps> = ({ onClose, events }) => {
+const CreateScheduleDate: React.FC<CalendarProps> = ({ onClose, events, mentoringRoomId }) => {
     const [selectedDate, setSelectedDate] = useState<Date | null>(null);
 
     // 현재는 각각 events 라는 상수로 지정해서 사용
@@ -90,7 +91,7 @@ const CreateScheduleDate: React.FC<CalendarProps> = ({ onClose, events }) => {
                     url: `${baseURL}`,
                     method: 'post',
                     data: {
-                        mentoringRoomId: 1,
+                        mentoringRoomId: mentoringRoomId,
                         mentorId: memberId,
                         start: startAt,
                         end: endAt

--- a/src/components/live/LiveList.tsx
+++ b/src/components/live/LiveList.tsx
@@ -2,11 +2,22 @@ import { useEffect, useState } from 'react';
 
 import CreateRoomModal from './CreateRoomModal';
 import SearchBar from './SearchBar';
-import RoomList, {Room} from './RoomList';
+import RoomList, { Room } from './RoomList';
 import React from 'react';
 import axios from 'axios';
 
-const LiveList: React.FC = () => {
+interface EventProp {
+    title: string;
+    startDate: Date;
+    endDate: Date;
+    type: string;
+};
+
+interface LiveListProps {
+    events: EventProp[];
+}
+
+const LiveList: React.FC<LiveListProps> = ({ events }) => {
     const [isModalOpen, setIsModalOpen] = useState(false);
     const [roomList, setRoomList] = useState<Room[]>([]);
 
@@ -19,49 +30,49 @@ const LiveList: React.FC = () => {
         const url = `http://localhost:9002/api/room${lastDateTimeParam}`;
         const data = await axios.get(url);
         return data.data.data;
-      };
+    };
 
-      let flag = false;
+    let flag = false;
 
-      useEffect(() => {
+    useEffect(() => {
         const fetchData = async () => {
-          const data = await fetchRooms(null);
-          setRoomList(data);
-          setCurrentPage(1);
+            const data = await fetchRooms(null);
+            setRoomList(data);
+            setCurrentPage(1);
         };
 
-        if(flag===false){
+        if (flag === false) {
             fetchData()
             flag = true;
         }
-      }, []);
+    }, []);
 
-      useEffect(() => {
+    useEffect(() => {
         const sliceEndIndex = currentPage * PAGE_SIZE;
         setDisplayedRooms(roomList.slice(0, sliceEndIndex));
-        console.log("검색 이후의 갯수"+roomList.length)
+        console.log("검색 이후의 갯수" + roomList.length)
         console.log(roomList)
-      }, [roomList, currentPage]);
+    }, [roomList, currentPage]);
 
-      const handleScroll = async () => {
+    const handleScroll = async () => {
         if (window.innerHeight + window.scrollY >= document.body.offsetHeight) {
-          if ((currentPage + 1) * PAGE_SIZE <=roomList.length) {
-            setCurrentPage(currentPage + 1);
-          } else { 
-            const lastRoom = roomList[roomList.length - 1];
-            const newRooms = await fetchRooms(lastRoom.createdAt);
-              setRoomList((prevRooms) => [...prevRooms, ...newRooms]);
-              setCurrentPage(currentPage+1);
-          }
+            if ((currentPage + 1) * PAGE_SIZE <= roomList.length) {
+                setCurrentPage(currentPage + 1);
+            } else {
+                const lastRoom = roomList[roomList.length - 1];
+                const newRooms = await fetchRooms(lastRoom.createdAt);
+                setRoomList((prevRooms) => [...prevRooms, ...newRooms]);
+                setCurrentPage(currentPage + 1);
+            }
         }
-      };
+    };
 
-      useEffect(() => {
+    useEffect(() => {
         window.addEventListener('scroll', handleScroll);
         return () => {
-          window.removeEventListener('scroll', handleScroll);
+            window.removeEventListener('scroll', handleScroll);
         };
-      }, [handleScroll]);
+    }, [handleScroll]);
 
     const handleOpenModal = () => {
         setIsModalOpen(true);
@@ -76,22 +87,22 @@ const LiveList: React.FC = () => {
     };
 
     return (
-       <div className="flex flex-col justify-center items-center">
-        <div className="w-1/2">
-            <SearchBar onSearch={handleSearch}></SearchBar>
+        <div className="flex flex-col justify-center items-center">
+            <div className="w-1/2">
+                <SearchBar onSearch={handleSearch}></SearchBar>
+            </div>
+            <div className="h-32 flex items-center">
+                <button
+                    className="py-2 px-4 bg-transparent text-red-600 font-semibold border border-red-600 rounded hover:bg-red-600 hover:text-white hover:border-transparent transition ease-in duration-200 transform hover:-translate-y-1 active:translate-y-0"
+                    onClick={handleOpenModal}>
+                    방 생성
+                </button>
+            </div>
+            <div>
+                <RoomList rooms={displayedRooms}></RoomList>
+            </div>
+            {isModalOpen && <CreateRoomModal onClose={() => setIsModalOpen(false)} events={events} />}
         </div>
-        <div className="h-32 flex items-center">
-            <button
-                className="py-2 px-4 bg-transparent text-red-600 font-semibold border border-red-600 rounded hover:bg-red-600 hover:text-white hover:border-transparent transition ease-in duration-200 transform hover:-translate-y-1 active:translate-y-0"
-                onClick={handleOpenModal}>
-                방 생성
-            </button>
-        </div>
-        <div>
-            <RoomList rooms={displayedRooms}></RoomList>
-        </div>
-        {isModalOpen && <CreateRoomModal onClose={() => setIsModalOpen(false)} />}
-    </div>
     );
 };
 

--- a/src/components/live/ShowSchedule.tsx
+++ b/src/components/live/ShowSchedule.tsx
@@ -1,12 +1,14 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import Popup from './PopUp';
+import axios from 'axios';
 import {
   Scheduler,
   WeekView,
   Appointments,
   Toolbar,
   TodayButton,
-  DateNavigator
+  DateNavigator,
+  Resources
 } from "@devexpress/dx-react-scheduler-material-ui";
 import { ViewState } from '@devexpress/dx-react-scheduler';
 
@@ -18,6 +20,15 @@ interface CancelEventPopupProps {
   handleClose: () => void;
   event: any;
 }
+
+const resources = [{
+  fieldName: 'type',
+  title: 'Type',
+  instances: [
+      { id: 'mentor', text: 'as mentor', color: '#EC407A' },
+      { id: 'mentee', text: 'as mentee', color: '#7E57C2' },
+  ],
+}];
 
 const CustomAppointment = (props: any) => {
   const handleEventClick = () => {
@@ -70,11 +81,14 @@ const ShowSchedule: React.FC<CalendarProps> = ({ events }) => {
     <div className="calendar">
       <Scheduler data={events} height={window.innerHeight-250}>
         <ViewState currentDate={currentDate} onCurrentDateChange={currentDateChange} />
-        <WeekView startDayHour={9} endDayHour={22} cellDuration={60} />
+        <WeekView startDayHour={7} endDayHour={23} cellDuration={60} />
         <Toolbar />
         <DateNavigator />
         <TodayButton />
         <Appointments appointmentComponent={(props) => <CustomAppointment {...props} onClick={handleEventClick} />} />
+        <Resources
+                                data={resources}
+                            />
       </Scheduler>
       {showCancelEventPopup && (
         <CancelEventPopup event={selectedEvent} handleClose={handleClosePopup} />

--- a/src/pages/Mentoring.tsx
+++ b/src/pages/Mentoring.tsx
@@ -2,9 +2,75 @@ import React, { useEffect, useState } from 'react';
 import ShowSchedule from '../components/live/ShowSchedule';
 import LiveList from '../components/live/LiveList';
 
+import axios from 'axios';
+
+interface ScheduleProps {
+  scheduleId: number;
+  mentoringRoomTitle: string;
+  mentorName: string;
+  menteeName: string;
+  startDate: string;
+  endDate: string;
+};
+
+interface EventProp {
+  title: string;
+  startDate: Date;
+  endDate: Date;
+  type: string;
+};
+
+const convertScheduleToEvents = (schedules: ScheduleProps[], isMentor: boolean): EventProp[] => {
+  const events: EventProp[] = [];
+
+  if (isMentor) {
+    schedules.forEach((schedule) => {
+      const event: EventProp = {
+        title: `${schedule.mentoringRoomTitle} with ${schedule.mentorName}`,
+        startDate: new Date(schedule.startDate),
+        endDate: new Date(schedule.endDate),
+        type: 'mentor'
+      };
+      events.push(event);
+    });
+  }
+  else {
+    schedules.forEach((schedule) => {
+      const event: EventProp = {
+        title: `Mentoring with ${schedule.menteeName}`,
+        startDate: new Date(schedule.startDate),
+        endDate: new Date(schedule.endDate),
+        type: 'mentee'
+      };
+      events.push(event);
+    });
+  }
+
+  return events;
+}
+
+const memberId = 1;
+
 const Mentoring = () => {
-  const [showPopup, setShowPopup] = useState(false); // 팝업 창 취소
   const [showScheduler, setShowScheduler] = useState(true); // 보여주는 창 변경
+  const [mySchedulesAsMentor, setMySchedulesAsMentor] = useState<ScheduleProps[]>([]);
+  const [mySchedulesAsMentee, setMySchedulesAsMentee] = useState<ScheduleProps[]>([]);
+
+  useEffect(() => {
+    // API와 통신하여 나의 모든 스케쥴(mySchedule) 가져오고,
+    axios({
+      url: `http://localhost:9002/api/schedules/mentor/${memberId}`,
+      method: 'get'
+    }).then((res) => {
+      setMySchedulesAsMentor(res.data['data']);
+    })
+    axios({
+      url: `http://localhost:9002/api/schedules/mentee/${memberId}`,
+      method: 'get'
+    }).then((res) => {
+      setMySchedulesAsMentee(res.data['data']);
+    })
+  }, [])
 
   const handleClickScheduler = () => {
     setShowScheduler(true);
@@ -14,61 +80,28 @@ const Mentoring = () => {
     setShowScheduler(false);
   }
 
-  const events = [
-    {
-      title: '테스트 1',
-      startDate: new Date(new Date().setHours(new Date().getHours() - 5)),
-      endDate: new Date(new Date().setHours(new Date().getHours() - 3)),
-    },
-    {
-      title: '테스트 2',
-      startDate: new Date(new Date().setHours(new Date().getHours())),
-      endDate: new Date(new Date().setHours(new Date().getHours()+1)),
-    },
-    {
-      title: '테스트 3',
-      startDate: new Date(new Date().setHours(new Date().getHours() + 12)),
-      endDate: new Date(new Date().setHours(new Date().getHours() + 14)),
-      location:"test-Room"
-    },
-    {
-      title: '테스트 3',
-      startDate: new Date(new Date().setHours(new Date().getHours() + 48)),
-      endDate: new Date(new Date().setHours(new Date().getHours() + 49)),
-      location:"test-Room"
-    },
-    {
-      title: '테스트 3',
-      startDate: new Date(new Date().setHours(new Date().getHours() + 75)),
-      endDate: new Date(new Date().setHours(new Date().getHours() + 77)),
-      location:"test-Room"
-    },
-  ]; // 임의의 스케쥴 event 값
-
   return (
     <div className="container mx-auto">
       <div className="flex mt-5 mb-3 justify-center">
         <button
-          className={`flex-1 py-2 px-4 border border-blue-500 text-center ${
-            showScheduler ? 'bg-blue-500' : 'bg-blue-300'
-          }`}
+          className={`flex-1 py-2 px-4 border border-blue-500 text-center ${showScheduler ? 'bg-blue-500' : 'bg-blue-300'
+            }`}
           onClick={handleClickScheduler}
         >
           일정 관리
         </button>
         <button
-          className={`flex-1 py-2 px-4 border border-blue- text-center ${
-            showScheduler ? 'bg-blue-300' : 'bg-blue-500'
-          }`}
+          className={`flex-1 py-2 px-4 border border-blue- text-center ${showScheduler ? 'bg-blue-300' : 'bg-blue-500'
+            }`}
           onClick={handleClickRoomList}
         >
           전체 방 목록
         </button>
       </div>
       {showScheduler ? (
-        <ShowSchedule events={events} />
-      ) : ( 
-        <LiveList></LiveList>
+        <ShowSchedule events={convertScheduleToEvents(mySchedulesAsMentor, true).concat(convertScheduleToEvents(mySchedulesAsMentee, false))} />
+      ) : (
+        <LiveList events={convertScheduleToEvents(mySchedulesAsMentor, true).concat(convertScheduleToEvents(mySchedulesAsMentee, false))}></LiveList>
       )}
     </div>
   );


### PR DESCRIPTION
## 🤔 Motivation

- 내 일정 모두 불러와서 scheduler에 보여주기 및 일정 추가

<br>

## 💡 Key Changes

- 현재는 제일 처음 `pages/Mentoring` 페이지가 랜더링될 때 서버에서 모든 일정을 가져와 뿌려주고, 이를 방 생성 및 일정 추가 모달창에서 `props`로 받아서 처리하도록 했습니다. 추후 `recoil` 사용해 전역변수로 관리하도록 할 예정입니다.

<br>

## 👨‍👨‍👧‍👦 To Reviewers

- @kcs-developers/start-dream-team 

close #46
close #47 