### PR TITLE
fix: 스케줄러 DateNavigator 추가

### DIFF
--- a/src/components/live/MentorScheduling.tsx
+++ b/src/components/live/MentorScheduling.tsx
@@ -63,10 +63,6 @@ const MentorScheduling: React.FC = () => {
             ))}
             {isModalOpen && (
                 <Popup>
-                    {/* <div>
-                        방 수정 및 일정 추가
-                    </div>
-                    <button onClick={() => setStep(1)}>나가기</button> */}
                     <ModifyRoomInfo room={selectedRoom} onClose={() => setIsModalOpen(false)}></ModifyRoomInfo>
                 </Popup>
             )}

--- a/src/components/live/ModifySchedule.tsx
+++ b/src/components/live/ModifySchedule.tsx
@@ -10,6 +10,7 @@ import {
     TodayButton,
     AppointmentTooltip,
     Resources,
+    DateNavigator
 } from "@devexpress/dx-react-scheduler-material-ui";
 
 import axios from "axios";
@@ -116,7 +117,7 @@ const ModifySchedule: React.FC<CalendarProps> = ({ onClose, mentoringRoomId }) =
             if (window.confirm('해당 시간을 취소하시겠습니까?')) {
                 console.log("event", event);
                 axios({
-                    url:`http://localhost:9002/api/schedules/mentor/${event.scheduleId}`,
+                    url: `http://localhost:9002/api/schedules/mentor/${event.scheduleId}`,
                     method: 'delete'
                 }).then((res) => {
                     console.log(res.data);
@@ -194,6 +195,7 @@ const ModifySchedule: React.FC<CalendarProps> = ({ onClose, mentoringRoomId }) =
                             <ViewState defaultCurrentDate={new Date()} />
                             <WeekView startDayHour={7} endDayHour={23} />
                             <Toolbar />
+                            <DateNavigator />
                             <TodayButton />
                             <Appointments appointmentComponent={(props) => <CustomAppointment {...props} onClick={handleEventClick} />} />
                             <AppointmentTooltip />


### PR DESCRIPTION
## 🤔 Motivation

- 일정 추가 시 보여지는 스케줄러에 DateNavigator 추가

<br>

## 💡 Key Changes

- 멘토 관리 페이지 내에서 방 정보 수정 및 일정 추가 시, 아래와 같은 Toolbar 를 보여지도록 하여 다음 일주일 뒤의 일정도 참고해 추가할 수 있도록 구현했습니다.
<img width="332" alt="image" src="https://user-images.githubusercontent.com/38252649/231956248-a17ffa8d-482f-4ed9-8670-4bc1ab03cd1c.png">


<br>

## 👨‍👨‍👧‍👦 To Reviewers

- @kcs-developers/start-dream-team 

close #59 
