### PR TITLE
chore: 요청전 토큰 만료여부 로직 삭제

### DIFF
--- a/src/apis/axiosConfig.ts
+++ b/src/apis/axiosConfig.ts
@@ -45,20 +45,8 @@ const onRequest = async (config: InternalAxiosRequestConfig) => {
   config.timeout = 15000;
 
   if (accessToken) {
-    /** 2. access 토큰 있으면 만료됐는지 체크 */
-    if (CheckJWTExp(accessToken, refreshToken) === ACCESS_EXP_MESSAGE) {
-      /** 3. access 만료되면 새로 발급받는 api 요청 */
-      const { data } = await axiosInstance.post(`/api/auth/refresh`, {
-        accessToken: accessToken,
-        refreshToken: refreshToken,
-      });
-      removeLocalStorage("access_token");
-      setLocalStorage("access_token", `${data.accessToken}`);
-      config.headers!.Authorization = `Bearer ${data.accessToken}`;
-    } else {
-      config.headers.Authorization = `Bearer ${accessToken}`;
-      return config;
-    }
+    config.headers.Authorization = `Bearer ${accessToken}`;
+    return config;
   }
   return config;
 };


### PR DESCRIPTION
## 🤔 Motivation

-

<br>

## 💡 Key Changes

- 응답으로 만료됐다고 왔을때만 refresh로 갱신하기
- 요청 전에 만료기한 검사해서 refresh 갱신 api 하는 로직 삭제함
- ==> 서버에서 내려준 만료 여부로만 갱신하기

<br>

## 👨‍👨‍👧‍👦 To Reviewers

- ***

close #이슈번호
