### PR TITLE
fix: 스케쥴 조회 및 빈 문자열 검색

### DIFF
--- a/src/components/live/LiveList.tsx
+++ b/src/components/live/LiveList.tsx
@@ -80,6 +80,12 @@ const LiveList: React.FC<LiveListProps> = ({ events }) => {
       setRoomList(data.data.data);
       setCurrentPage(1);
     }
+    // 빈칸 입력하면 모든 데이터 가져오도록
+    else {
+      const data = await fetchRooms(null);
+      setRoomList(data);
+      setCurrentPage(1);
+    }
   };
 
   return (

--- a/src/components/live/RoomList.tsx
+++ b/src/components/live/RoomList.tsx
@@ -17,12 +17,12 @@ interface RoomListProps {
 }
 
 export const thumbnails = [
-  "https://picsum.photos/id/237/200/300",
-  "https://picsum.photos/id/238/200/300",
-  "https://picsum.photos/id/239/200/300",
-  "https://picsum.photos/id/240/200/300",
-  "https://picsum.photos/id/241/200/300",
-  "https://picsum.photos/id/242/200/300",
+  "https://picsum.photos/id/0/300/200",
+  "https://picsum.photos/id/1/300/200",
+  "https://picsum.photos/id/2/300/200",
+  "https://picsum.photos/id/3/300/200",
+  "https://picsum.photos/id/4/300/200",
+  "https://picsum.photos/id/5/300/200",
 ];
 
 const RoomList: React.FC<RoomListProps> = ({ events, rooms }) => {
@@ -31,10 +31,8 @@ const RoomList: React.FC<RoomListProps> = ({ events, rooms }) => {
   const [showRoomInfo, setShowRoomInfo] = useState(false);
 
   const handleShowRoomInfo = (room: Room) => {
-    if (memberId) {
-      setSelectedRoom(room);
-      setShowRoomInfo(!showRoomInfo);
-    }
+    setSelectedRoom(room);
+    setShowRoomInfo(!showRoomInfo);
   };
 
   return (

--- a/src/components/live/ShowMentoring.tsx
+++ b/src/components/live/ShowMentoring.tsx
@@ -14,6 +14,8 @@ interface ShowMentoringProps {
   handleClose: () => void;
 }
 
+const offset = new Date().getTimezoneOffset() * 60000;
+
 const ShowMentoring: React.FC<ShowMentoringProps> = ({
   mySchedule,
   room,
@@ -36,11 +38,17 @@ const ShowMentoring: React.FC<ShowMentoringProps> = ({
 
   if (roomSchedules.length !== 0) {
     newSchedule = roomSchedules.filter(
-      (roomSchedule) =>
-        !mySchedule.some(
-          (my) => my.startDate.toString() === roomSchedule.startDate
-        )
-    );
+      // 멘토링 시작 시간이 현재 시간보다 이른 경우 제외
+      (roomSchedule) => (
+        roomSchedule.startDate > new Date(new Date().getTime() - offset).toISOString()
+      ))
+      .filter(
+        (roomSchedule) => (
+          !mySchedule.some(
+            (my) => 
+              my.startDate.toLocaleString() === new Date(roomSchedule.startDate).toLocaleString()
+          )
+        ))
   }
 
   return (


### PR DESCRIPTION
## 🤔 Motivation

- 스케쥴 조회 및 빈 문자열 검색

<br>

## 💡 Key Changes

- 멘토링 신청 가능 일정 조회할 때, 시작 시간이 현재 시간보다 이르다면 아예 안보이도록 수정했습니다.
- 검색창에 빈 문자열 입력했을 때 다시 초기값으로 기본 시간순 정렬 데이터를 가져오도록 했습니다.

<br>

## 👨‍👨‍👧‍👦 To Reviewers

- @kcs-developers/start-dream-team @paduck-96 @Jooney-95 

close #이슈번호
