### PR TITLE
fix: 일정 추가 가능 시간 및 기타 수정

### DIFF
--- a/src/components/live/CreateScheduleModal.tsx
+++ b/src/components/live/CreateScheduleModal.tsx
@@ -79,21 +79,30 @@ const CreateScheduleDate: React.FC<CalendarProps> = ({
   const [availableTimeSlots, setAvailableTimeSlots] =
     useState<string[]>(allTimeSlots);
 
-  useEffect(() => {
-    if (selectedDate) {
-      // 예약 가능한 시간대 계산
-      const reservedTimes = events
-        .filter(
-          (event) =>
-            event.startDate.toDateString() === selectedDate.toDateString()
-        )
-        .map((event) => event.startDate.getHours().toString());
-      const availableTimes = allTimeSlots.filter(
-        (time) => !reservedTimes.includes(time)
-      );
-      setAvailableTimeSlots(availableTimes);
-    }
-  }, [selectedDate, events]);
+    useEffect(() => {
+      if (selectedDate) {
+        let availableTimes: string[] = allTimeSlots;
+        // 선택 날짜(selectedDate) 가 오늘일 때, 현재 시간보다 이른 시간은 신청하지 못하도록
+        if (selectedDate.getDate() === new Date().getDate()) {
+          availableTimes = availableTimes.filter(
+            (time) =>
+              parseInt(time) > new Date().getHours()
+          )
+        }
+        // 예약 가능한 시간대 계산
+        const reservedTimes = events
+          .filter(
+            (event) =>
+              new Date(event.startDate).toDateString() ===
+              selectedDate.toDateString()
+          )
+          .map((event) => new Date(event.startDate).getHours().toString());
+        availableTimes = availableTimes.filter(
+          (time) => !reservedTimes.includes(time)
+        );
+        setAvailableTimeSlots(availableTimes);
+      }
+    }, [selectedDate, events]);
 
   // 예약 가능한 시간대 버튼을 동적으로 생성해주는 함수
   const renderTimeSlotButtons = () => {

--- a/src/components/live/MentorScheduling.tsx
+++ b/src/components/live/MentorScheduling.tsx
@@ -79,7 +79,11 @@ const MentorScheduling: React.FC<MentorSchedulingProps> = ({ events }) => {
           </div>
           <button
             className="bg-accent-500 text-white px-4 my-2 rounded-md"
-            onClick={() => handleRemoveSchedule(room)}
+            onClick={(e) => {
+              // 버블링 이벤트 방지
+              e.stopPropagation();
+              handleRemoveSchedule(room)
+            }}
           >
             삭제
           </button>

--- a/src/components/live/ModifySchedule.tsx
+++ b/src/components/live/ModifySchedule.tsx
@@ -78,6 +78,14 @@ const ModifySchedule: React.FC<CalendarProps> = ({ onClose, room, events }) => {
 
   useEffect(() => {
     if (selectedDate) {
+      let availableTimes: string[] = allTimeSlots;
+      // 선택 날짜(selectedDate) 가 오늘일 때, 현재 시간보다 이른 시간은 신청하지 못하도록
+      if (selectedDate.getDate() === new Date().getDate()) {
+        availableTimes = availableTimes.filter(
+          (time) =>
+            parseInt(time) > new Date().getHours()
+        )
+      }
       // 예약 가능한 시간대 계산
       const reservedTimes = events
         .filter(
@@ -86,7 +94,7 @@ const ModifySchedule: React.FC<CalendarProps> = ({ onClose, room, events }) => {
             selectedDate.toDateString()
         )
         .map((event) => new Date(event.startDate).getHours().toString());
-      const availableTimes = allTimeSlots.filter(
+      availableTimes = availableTimes.filter(
         (time) => !reservedTimes.includes(time)
       );
       setAvailableTimeSlots(availableTimes);
@@ -100,6 +108,7 @@ const ModifySchedule: React.FC<CalendarProps> = ({ onClose, room, events }) => {
 
   const handleClosePopup = () => {
     setShowCancelEventPopup(false);
+    onClose();
   };
 
   const CustomAppointment = (props: any) => {


### PR DESCRIPTION
## 🤔 Motivation

- 일정 추가 가능한 시간 수정
- 방 수정 - 일정 추가 및 삭제 후 모달 처리
- 버튼 클릭 시 버블링 문제로 수정 

<br>

## 💡 Key Changes

- `방 수정`(또는 `방 생성`) - `일정 추가` 에서 추가 가능한 시간대를 현재 시간보다 이른 시간은 보여주지 않도록 수정했습니다.
- 방 수정 - 일정 추가 및 삭제 후, 자동으로 모달 창이 닫히도록 했습니다.
- 멘토 관리에서 `방 삭제` 버튼 클릭 시, 같이 되던 방 클릭도 같이 되었던 문제가 수정되었습니다.

<br>

## 👨‍👨‍👧‍👦 To Reviewers

- @kcs-developers/start-dream-team @paduck-96 @Jooney-95 

close #이슈번호
