### PR TITLE
fix: schedule color, event click

### DIFF
--- a/src/components/live/LiveList.tsx
+++ b/src/components/live/LiveList.tsx
@@ -75,18 +75,20 @@ const LiveList: React.FC<LiveListProps> = ({ events }) => {
 
   const handleSearch = async (query: string) => {
     if (query) {
-      const url = `/api/room/${query}`;
+      // 1개 이상의 공백을 1개로 바꿔 보내주도록하고 앞, 뒤 공백 제거
+      const url = `/api/room/${query.replace(/\s+/g, ' ').trim()}`;
       const data = await axiosInstance.get(url);
-      setRoomList(data.data.data);
+      setRoomList([...data.data.data]);
       setCurrentPage(1);
     }
     // 빈칸 입력하면 모든 데이터 가져오도록
     else {
       const data = await fetchRooms(null);
-      setRoomList(data);
+      setRoomList([...data]);
       setCurrentPage(1);
     }
   };
+  
 
   return (
     <div className="flex flex-col justify-center items-center">

--- a/src/components/live/ShowSchedule.tsx
+++ b/src/components/live/ShowSchedule.tsx
@@ -31,8 +31,8 @@ const resources = [
     fieldName: "type",
     title: "Type",
     instances: [
-      { id: "mentor", text: "as mentor", color: "#EC407A" },
-      { id: "mentee", text: "as mentee", color: "#7E57C2" },
+      { id: "mentor", text: "as mentor", color: "#6246EA" },
+      { id: "mentee", text: "as mentee", color: "#e45858" },
     ],
   },
 ];
@@ -197,15 +197,14 @@ const CancelEventPopup: React.FC<CancelEventPopupProps> = ({
         >
           입장하기
         </button>
-        {isMentor && (
+        {isMentor && memberInfo.nickname === event.owner ? (
           <button
             className="bg-red-200 hover:bg-red-300 px-3 py-2 mr-3 rounded"
             onClick={handleRemoveEvent}
           >
             종료하기
           </button>
-        )}
-        {!isMentor && (
+        ) : (
           <button
             className="bg-blue-200 hover:bg-blue-300 px-3 py-2 mr-3 rounded"
             onClick={handleCancelEvent}
@@ -244,30 +243,36 @@ const ShowSchedule: React.FC<CalendarProps> = ({ events, isMentor }) => {
   };
 
   return (
-    <div className="calendar">
-      <Scheduler data={events} height={window.innerHeight - 250}>
-        <ViewState
-          currentDate={currentDate}
-          onCurrentDateChange={currentDateChange}
-        />
-        <WeekView startDayHour={7} endDayHour={23} cellDuration={60} />
-        <Toolbar />
-        <DateNavigator />
-        <TodayButton />
-        <Appointments
-          appointmentComponent={(props) => (
-            <CustomAppointment {...props} onClick={handleEventClick} />
-          )}
-        />
-        <Resources data={resources} />
-      </Scheduler>
-      {showCancelEventPopup && (
-        <CancelEventPopup
-          event={selectedEvent}
-          handleClose={handleClosePopup}
-          isMentor={isMentor}
-        />
-      )}
+    <div>
+      <div className="flex justify-end">
+        <span className="text-[#6246EA] font-bold">멘토&nbsp;</span>
+        <span className="text-[#E45858] font-bold">멘티</span>
+        </div>
+      <div className="calendar">
+        <Scheduler data={events} height={window.innerHeight - 250}>
+          <ViewState
+            currentDate={currentDate}
+            onCurrentDateChange={currentDateChange}
+          />
+          <WeekView startDayHour={7} endDayHour={23} cellDuration={60} />
+          <Toolbar />
+          <DateNavigator />
+          <TodayButton />
+          <Appointments
+            appointmentComponent={(props) => (
+              <CustomAppointment {...props} onClick={handleEventClick} />
+            )}
+          />
+          <Resources data={resources} />
+        </Scheduler>
+        {showCancelEventPopup && (
+          <CancelEventPopup
+            event={selectedEvent}
+            handleClose={handleClosePopup}
+            isMentor={isMentor}
+          />
+        )}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## 🤔 Motivation

- 스케쥴러에 표시되는 색상 변경
- 스케쥴러 일정 클릭 시 뜨는 팝업창 로직 변경

<br>

## 💡 Key Changes

- 스케쥴러에 표시되는 색상을 변경하고, 상단에 일정이 멘토로서의 일정인지, 멘티로서의 일정인지 구분할 수 있도록 정보를 추가했습니다.
<img width="1096" alt="image" src="https://user-images.githubusercontent.com/38252649/234203342-839c0a23-9715-42a9-a181-d0b6b1a7ff36.png">

- 기존에 메인 스케쥴러에서 `isMentor` 만을 판단하여 뜨는 팝업창의 로직을 변경했었는데, 일정마다 해당 일정의 멘토인지 멘티인지 판단하여 팝업을 달리 띄우도록 수정했습니다.

<br>

## 👨‍👨‍👧‍👦 To Reviewers

- @kcs-developers/start-dream-team @paduck-96 @Jooney-95 

close #이슈번호
