### PR TITLE
[Feat] 메인페이지 포인트 랭킹 TOP 10 콘텐츠 추가

### DIFF
--- a/src/apis/apis.ts
+++ b/src/apis/apis.ts
@@ -82,3 +82,8 @@ export const PROBLEM_API = {
     });
   },
 };
+export const POINT_API = {
+  getPointRanking: () => {
+    return axiosInstance({ method: "GET", url: `/api/member/point/ranking` });
+  },
+};

--- a/src/components/MainList.tsx
+++ b/src/components/MainList.tsx
@@ -27,15 +27,26 @@ interface RoomsProps {
   mentoringRoomId: number;
   title: string;
 }
+interface RankingProps {
+  nickname: string;
+  point: number;
+}
 
 type MainListType = {
   sectionHeader: string;
   option: string;
   problems?: MainListProps[];
   rooms?: RoomsProps[];
+  ranking?: RankingProps[];
 };
 
-const MainList = ({ sectionHeader, option, problems, rooms }: MainListType) => {
+const MainList = ({
+  sectionHeader,
+  option,
+  problems,
+  rooms,
+  ranking,
+}: MainListType) => {
   return (
     <>
       <div className="flex flex-col">
@@ -112,6 +123,21 @@ const MainList = ({ sectionHeader, option, problems, rooms }: MainListType) => {
                   <div className="text-sm">{el.createdAt.slice(0, 10)}</div>
                 </div>
               </Link>
+            ))}
+          </>
+        )}
+        {option === "ranking" && (
+          <>
+            {ranking?.length === 0 && (
+              <div className="font-thin py-16 flex justify-center">
+                가입한 사용자가 없습니다.
+              </div>
+            )}
+            {ranking!.map((el, idx) => (
+              <div className="flex justify-between">
+                <div className="text-sm font-medium">{el.nickname} &nbsp;</div>
+                <div className="text-sm">{el.point}점</div>
+              </div>
             ))}
           </>
         )}

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -1,4 +1,4 @@
-import { PROBLEM_API, ROOM_API } from "apis/apis";
+import { POINT_API, PROBLEM_API, ROOM_API } from "apis/apis";
 import Carousel from "components/Carousel";
 import MainList from "components/MainList";
 import { useEffect, useState } from "react";
@@ -8,6 +8,7 @@ const Main = () => {
   const [roomLikes, setRoomLikes] = useState([]);
   const [problemNew, setProblemNew] = useState([]);
   const [problemLikes, setProblemLikes] = useState([]);
+  const [pointRanking, setPointRanking] = useState([]);
   useEffect(() => {
     const getRoomNewest = async () => {
       const {
@@ -33,10 +34,19 @@ const Main = () => {
       } = await PROBLEM_API.getProblemLikes();
       setProblemLikes(data.slice(0, 5));
     };
+    const getPointRanking = async () => {
+      const {
+        data: { data },
+      } = await POINT_API.getPointRanking();
+      console.log(data);
+      setPointRanking(data.pointRanking);
+      console.log(pointRanking);
+    };
     getRoomNewest();
     // getRoomLike();
     getProblemNewest();
     getProblemLike();
+    getPointRanking();
   }, []);
 
   return (
@@ -51,17 +61,17 @@ const Main = () => {
         <MainList
           rooms={roomTop}
           option="room"
-          sectionHeader={"최근 개설된 채팅방"}
+          sectionHeader={"최근 개설된 멘토링룸"}
         />
         <MainList
           problems={problemLikes}
           option="problem"
-          sectionHeader={"이번 주 추천 문제"}
+          sectionHeader={"오늘의 추천 문제"}
         />
         <MainList
-          rooms={roomTop}
-          option="room"
-          sectionHeader={"WEEKLY ROOM BEST"}
+          ranking={pointRanking}
+          option="ranking"
+          sectionHeader={"포인트 랭킹 TOP 10"}
         />
       </div>
     </div>


### PR DESCRIPTION
## 🤔 Motivation

- 메인페이지 포인트 랭킹 TOP 10 콘텐츠 추가

<br>

## 💡 Key Changes

- 메인페이지 우측 하단 콘텐츠에 모든 사용자 포인트 랭킹 TOP 10 데이터를 보여주도록 추가했습니다.

![image](https://user-images.githubusercontent.com/59594946/235210354-6bc6718c-04f1-4fd6-b0aa-94d38d2e71df.png)


<br>

## 👨‍👨‍👧‍👦 To Reviewers

- @kcs-developers/start-dream-team 
